### PR TITLE
Added scl-utils package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 	openssl-devel \
 	postgresql-devel \
 	procps-ng \
+	scl-utils \
 	sqlite-devel \
 	tar \
 	unzip \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -22,6 +22,7 @@ RUN yum install -y --setopt=tsflags=nodocs \
 	openssl-devel \
 	postgresql-devel \
 	procps-ng \
+	scl-utils \
 	sqlite-devel \
 	tar \
 	unzip \


### PR DESCRIPTION
Apparently `scl-utils` is not installed anymore by default both in rhel7 and centos7. 

//cc @mfojtik @jhadvig @mnagy @bparees 