### PR TITLE
Add findutils to list of packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 	automake \
 	bsdtar \
 	curl-devel \
+	findutils \
 	epel-release \
 	gcc-c++ \
 	gdb \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -23,6 +23,7 @@ RUN yum install -y --setopt=tsflags=nodocs \
 	automake \
 	bsdtar \
 	curl-devel \
+	findutils \
 	gcc-c++ \
 	gdb \
 	gettext \


### PR DESCRIPTION
Because "You should install findutils because it includes tools that
are very useful for finding things on your system."
(yum info findutils)

------------
I need `find` in the Python image. @bparees @mfojtik PTAL.