### PR TITLE
Added support for io.openshift.sti.scripts-url label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ FROM centos:centos7
 MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
 
 # Location of the STI scripts inside the image
+LABEL io.openshift.sti.scripts-url=image:///usr/local/sti
+# Deprecated. Use above LABEL instead, because this will be removed in future versions.
+ENV STI_SCRIPTS_URL=image:///usr/local/sti
+
 # The $HOME is not set by default, but some applications needs this variable
-ENV STI_SCRIPTS_URL=image:///usr/local/sti \
-    HOME=/opt/openshift/src \
+ENV HOME=/opt/openshift/src \
     PATH=/opt/openshift/src/bin:/opt/openshift/bin:/usr/local/sti:$PATH
 
 # This is the list of basic dependencies that all language Docker image can

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -4,14 +4,16 @@ FROM rhel7
 MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
 
 # Location of the STI scripts inside the image
+LABEL io.openshift.sti.scripts-url=image:///usr/local/sti
+# Deprecated. Use above LABEL instead, because this will be removed in future versions.
+ENV STI_SCRIPTS_URL=image:///usr/local/sti
+
 # The $HOME is not set by default, but some applications needs this variable
 # TODO: There is a bug in rhel7.1 image where the PATH variable is not exported
 # properly as Docker image metadata, which causes the $PATH variable do not
 # expand properly.
-ENV STI_SCRIPTS_URL=image:///usr/local/sti \
-    HOME=/opt/openshift/src \
+ENV HOME=/opt/openshift/src \
     PATH=/opt/openshift/src/bin:/opt/openshift/bin:/usr/local/sti:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-#ENV PATH             /opt/openshift/src/bin:/opt/openshift/bin:/usr/local/sti:$PATH
 
 # This is the list of basic dependencies that all language Docker image can
 # consume.


### PR DESCRIPTION
I've added support for `io.openshift.sti-scripts-url` label, but I'm keeping `STI_SCRIPTS_URL` environment variable for compatibility with previous sti and openshift builder versions.

/fyi @bparees @mnagy @jhadvig @mfojtik @kargakis @rhcarvalho 