### PR TITLE
Add BASH_ENV so $HOME/.bashrc is sourced automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV STI_SCRIPTS_URL=image:///usr/local/sti
 
 # The $HOME is not set by default, but some applications needs this variable
 ENV HOME=/opt/openshift/src \
+    BASH_ENV=/opt/openshift/src/.bashrc \
     PATH=/opt/openshift/src/bin:/opt/openshift/bin:/usr/local/sti:$PATH
 
 # This is the list of basic dependencies that all language Docker image can

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -13,6 +13,7 @@ ENV STI_SCRIPTS_URL=image:///usr/local/sti
 # properly as Docker image metadata, which causes the $PATH variable do not
 # expand properly.
 ENV HOME=/opt/openshift/src \
+    BASH_ENV=/opt/openshift/src/.bashrc \
     PATH=/opt/openshift/src/bin:/opt/openshift/bin:/usr/local/sti:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # This is the list of basic dependencies that all language Docker image can


### PR DESCRIPTION
This will allow us to remove all `source .bashrc` lines from the
downstream images.

@mfojtik PTAL. I tested it with sti-perl and tests are passing :)