### PR TITLE
Enable SCL globally without sourcing bashrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV STI_SCRIPTS_URL=image:///usr/local/sti
 
 # The $HOME is not set by default, but some applications needs this variable
 ENV HOME=/opt/openshift/src \
+    BASH_ENV=/opt/openshift/src/.bashrc \
     PATH=/opt/openshift/src/bin:/opt/openshift/bin:/usr/local/sti:$PATH
 
 # This is the list of basic dependencies that all language Docker image can

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,38 +18,38 @@ ENV HOME=/opt/openshift/src \
 # application runtime execution.
 # TODO: Use better UID and GID values
 RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-	yum install -y --setopt=tsflags=nodocs \
-	autoconf \
-	automake \
-	bsdtar \
-	libcurl-devel \
-	findutils \
-	epel-release \
-	gcc-c++ \
-	gdb \
-	gettext \
-	git \
-	libxml2-devel \
-	libxslt-devel \
-	lsof \
-	make \
-	openssl-devel \
-	patch \
-	postgresql-devel \
-	procps-ng \
-	scl-utils \
-	sqlite-devel \
-	tar \
-	unzip \
-	wget \
-	which \
-	yum-utils \
-	zlib-devel && \
-	yum clean all -y && \
-	mkdir -p ${HOME} && \
-	groupadd -r default -f -g 1001 && \
-	useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
-			-c "Default Application User" default
+  yum install -y --setopt=tsflags=nodocs \
+  autoconf \
+  automake \
+  bsdtar \
+  libcurl-devel \
+  findutils \
+  epel-release \
+  gcc-c++ \
+  gdb \
+  gettext \
+  git \
+  libxml2-devel \
+  libxslt-devel \
+  lsof \
+  make \
+  openssl-devel \
+  patch \
+  postgresql-devel \
+  procps-ng \
+  scl-utils \
+  sqlite-devel \
+  tar \
+  unzip \
+  wget \
+  which \
+  yum-utils \
+  zlib-devel && \
+  yum clean all -y && \
+  mkdir -p ${HOME} && \
+  groupadd -r default -f -g 1001 && \
+  useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
+      -c "Default Application User" default
 
 # Create directory where the image STI scripts will be located
 # Install the base-usage script with base image usage informations

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -13,6 +13,7 @@ ENV STI_SCRIPTS_URL=image:///usr/local/sti
 # properly as Docker image metadata, which causes the $PATH variable do not
 # expand properly.
 ENV HOME=/opt/openshift/src \
+    BASH_ENV=/opt/openshift/src/.bashrc \
     PATH=/opt/openshift/src/bin:/opt/openshift/bin:/usr/local/sti:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # This is the list of basic dependencies that all language Docker image can

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -21,36 +21,36 @@ ENV HOME=/opt/openshift/src \
 # application runtime execution.
 # TODO: Use better UID and GID values
 RUN yum install -y --setopt=tsflags=nodocs \
-	autoconf \
-	automake \
-	bsdtar \
-	libcurl-devel \
-	findutils \
-	gcc-c++ \
-	gdb \
-	gettext \
-	git \
-	libxml2-devel \
-	libxslt-devel \
-	lsof \
-	make \
-	openssl-devel \
-	patch \
-	postgresql-devel \
-	procps-ng \
-	scl-utils \
-	sqlite-devel \
-	tar \
-	unzip \
-	wget \
-	which \
-	yum-utils \
-	zlib-devel && \
-	yum clean all -y && \
-	mkdir -p ${HOME} && \
-	groupadd -r default -f -g 1001 && \
-	useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
-			-c "Default Application User" default
+  autoconf \
+  automake \
+  bsdtar \
+  libcurl-devel \
+  findutils \
+  gcc-c++ \
+  gdb \
+  gettext \
+  git \
+  libxml2-devel \
+  libxslt-devel \
+  lsof \
+  make \
+  openssl-devel \
+  patch \
+  postgresql-devel \
+  procps-ng \
+  scl-utils \
+  sqlite-devel \
+  tar \
+  unzip \
+  wget \
+  which \
+  yum-utils \
+  zlib-devel && \
+  yum clean all -y && \
+  mkdir -p ${HOME} && \
+  groupadd -r default -f -g 1001 && \
+  useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
+      -c "Default Application User" default
 
 # Create directory where the image STI scripts will be located
 # Install the base-usage script with base image usage informations

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,14 @@
-
 ifeq ($(TARGET),rhel7)
 	OS := rhel7
 else
 	OS := centos7
 endif
 
-
 .PHONY: build
 build:
 	hack/build.sh $(OS)
 
-
 .PHONY: test
 test:
-	hack/build.sh $(OS)-candidate
+	SKIP_SQUASH=$(SKIP_SQUASH) hack/build.sh $(OS)-candidate
 	IMAGE_NAME=openshift/base-$(OS)-candidate test/run

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -15,22 +15,24 @@ function squash {
 # TODO: Remove this hack once Docker 1.5 is in use,
 # which supports building of named Dockerfiles.
 function docker_build {
-	TAG=$1
-	DOCKERFILE=$2
+  TAG=$1
+  DOCKERFILE=$2
 
-	if [ -n "$DOCKERFILE" -a "$DOCKERFILE" != "Dockerfile" ]; then
-		# Swap Dockerfiles and setup a trap restoring them
-		mv Dockerfile Dockerfile.centos7
-		mv "${DOCKERFILE}" Dockerfile
-		trap "mv Dockerfile ${DOCKERFILE} && mv Dockerfile.centos7 Dockerfile" ERR RETURN
-	fi
+  if [ -n "$DOCKERFILE" -a "$DOCKERFILE" != "Dockerfile" ]; then
+    # Swap Dockerfiles and setup a trap restoring them
+    mv Dockerfile Dockerfile.centos7
+    mv "${DOCKERFILE}" Dockerfile
+    trap "mv Dockerfile ${DOCKERFILE} && mv Dockerfile.centos7 Dockerfile" ERR RETURN
+  fi
 
-	docker build -t ${TAG} . && trap - ERR
-	squash
+  docker build -t ${TAG} . && trap - ERR
+  [ -z "${SKIP_SQUASH}" ] && squash
+
+  return 0
 }
 
 if [ "$OS" == "rhel7" -o "$OS" == "rhel7-candidate" ]; then
-	docker_build ${IMAGE_NAME} Dockerfile.rhel7
+  docker_build ${IMAGE_NAME} Dockerfile.rhel7
 else
-	docker_build ${IMAGE_NAME}
+  docker_build ${IMAGE_NAME}
 fi


### PR DESCRIPTION
This PR enables the SCL collections globally by using BASH_ENV to inject the `scl enable` to every `/bin/bash` session.

This require change to every image we have, so don't merge it on its own, this have to be merged together with other PR's I will link to this PR.