### PR TITLE
Replacing centos7 base with origin-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM openshift/origin-base
 
 # This image is the base image for all OpenShift v3 language Docker images.
 MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
@@ -30,12 +30,10 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   autoconf \
   automake \
   bsdtar \
-  epel-release \
   findutils \
   gcc-c++ \
   gdb \
   gettext \
-  git \
   libcurl-devel \
   libxml2-devel \
   libxslt-devel \
@@ -49,9 +47,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   procps-ng \
   scl-utils \
   sqlite-devel \
-  tar \
   unzip \
-  wget \
   which \
   yum-utils \
   zlib-devel && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7
+FROM openshift/ose-base
 
 # This image is the base image for all OpenShift v3 language Docker images.
 MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
@@ -42,7 +42,6 @@ RUN yum install -y --setopt=tsflags=nodocs \
   gcc-c++ \
   gdb \
   gettext \
-  git \
   libcurl-devel \
   libxml2-devel \
   libxslt-devel \
@@ -56,9 +55,7 @@ RUN yum install -y --setopt=tsflags=nodocs \
   procps-ng \
   scl-utils \
   sqlite-devel \
-  tar \
   unzip \
-  wget \
   which \
   yum-utils \
   zlib-devel && \


### PR DESCRIPTION
Base on https://github.com/openshift/sti-base/issues/30

I think I would be also appropriate to change the base-rhel7 base image accordingly, since this change introduces inconsistency between base-centos7 and base-rhel7, but since we dont have any openshift/origin-base-rhel7 we will need to keep the change in mind.