### PR TITLE
Change owner of /opt/openshift in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   mkdir -p ${HOME} && \
   groupadd -r default -f -g 1001 && \
   useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default
+      -c "Default Application User" default && \
+  chown -R 1001:1001 /opt/openshift
 
 # Create directory where the image STI scripts will be located
 # Install the base-usage script with base image usage informations

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -66,12 +66,12 @@ RUN yum install -y --setopt=tsflags=nodocs \
   mkdir -p ${HOME} && \
   groupadd -r default -f -g 1001 && \
   useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default
+      -c "Default Application User" default && \
+  chown -R 1001:1001 /opt/openshift
 
 # Create directory where the image STI scripts will be located
 # Install the base-usage script with base image usage informations
 ADD bin/base-usage /usr/local/sti/base-usage
-
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path


### PR DESCRIPTION
This will allow to drop the `chown` from all Dockerfiles (as long as you copy the files in the directory **after** you drop to USER 1001. 

This can be merged without any harm (as the existing images will just do chown anyway. I'll be removing the chown in the other PR (namespace fix). So this should go in before that...