### PR TITLE
Fix comparison in hack/build.sh

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -14,12 +14,12 @@ function squash {
 
 if [ "$OS" == "rhel7" -o "$OS" == "rhel7-candidate" ]; then
   docker build -t ${IMAGE_NAME} -f Dockerfile.rhel7 .
-  if [ "${SKIP_SQUASH}" -ne "1" ]; then
+  if [[ "${SKIP_SQUASH}" != "1" ]]; then
     squash Dockerfile.rhel7
   fi
 else
   docker build -t ${IMAGE_NAME} .
-  if [ "${SKIP_SQUASH}" -ne "1" ]; then
+  if [[ "${SKIP_SQUASH}" != "1" ]]; then
     squash Dockerfile
   fi
 fi


### PR DESCRIPTION
Fixes these errors:

```console
...
Successfully built c4c003e04662
hack/build.sh: line 22: [: : integer expression expected
Building and testing openshift/base-rhel7:e651aac ...
...
```

(iow. the case shen SKIP_SQUASH is not defined)