### PR TITLE
Use /usr/bin for sti scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,17 @@ MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
 
 # Location of the STI scripts inside the image
 #
-LABEL io.openshift.s2i.scripts-url=image:///usr/local/sti
+LABEL io.openshift.s2i.scripts-url=image:///usr/bin
 
 # DEPRECATED: This label will be kept here for backward compatibility
-LABEL io.s2i.scripts-url=image:///usr/local/sti
+LABEL io.s2i.scripts-url=image:///usr/bin
 
 # Deprecated. Use above LABEL instead, because this will be removed in future versions.
-ENV STI_SCRIPTS_URL=image:///usr/local/sti
+ENV STI_SCRIPTS_URL=image:///usr/bin
 
 # The $HOME is not set by default, but some applications needs this variable
 ENV HOME=/opt/app-root/src \
-    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sti:$PATH
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
@@ -69,7 +69,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 
 # Create directory where the image STI scripts will be located
 # Install the base-usage script with base image usage informations
-ADD bin/base-usage /usr/local/sti/base-usage
+ADD bin/base-usage /usr/bin/base-usage
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL io.s2i.scripts-url=image:///usr/libexec/s2i
 # Deprecated. Use above LABEL instead, because this will be removed in future versions.
 ENV STI_SCRIPTS_URL=image:///usr/libexec/s2i
 
-# Path to be used in other layers to place s2i scritps into
+# Path to be used in other layers to place s2i scripts into
 ENV STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 # The $HOME is not set by default, but some applications needs this variable

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,16 @@ MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
 
 # Location of the STI scripts inside the image
 #
-LABEL io.openshift.s2i.scripts-url=image:///usr/bin
+LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 
 # DEPRECATED: This label will be kept here for backward compatibility
-LABEL io.s2i.scripts-url=image:///usr/bin
+LABEL io.s2i.scripts-url=image:///usr/libexec/s2i
 
 # Deprecated. Use above LABEL instead, because this will be removed in future versions.
-ENV STI_SCRIPTS_URL=image:///usr/bin
+ENV STI_SCRIPTS_URL=image:///usr/libexec/s2i
+
+# Path to be used in other layers to place s2i scritps into
+ENV STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 # The $HOME is not set by default, but some applications needs this variable
 ENV HOME=/opt/app-root/src \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -4,13 +4,16 @@ FROM rhel7
 MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
 
 # Location of the STI scripts inside the image
-LABEL io.openshift.s2i.scripts-url=image:///usr/bin
+LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 
 # DEPRECATED: This label will be kept here for backward compatibility
-LABEL io.s2i.scripts-url=image:///usr/bin
+LABEL io.s2i.scripts-url=image:///usr/libexec/s2i
 
 # Deprecated. Use above LABEL instead, because this will be removed in future versions.
-ENV STI_SCRIPTS_URL=image:///usr/bin
+ENV STI_SCRIPTS_URL=image:///usr/libexec/s2i
+
+# Path to be used in other layers to place s2i scritps into
+ENV STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 # Labels consumed by Red Hat build service
 LABEL BZComponent="openshift-sti-base-docker" \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -4,13 +4,13 @@ FROM rhel7
 MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
 
 # Location of the STI scripts inside the image
-LABEL io.openshift.s2i.scripts-url=image:///usr/local/sti
+LABEL io.openshift.s2i.scripts-url=image:///usr/bin
 
 # DEPRECATED: This label will be kept here for backward compatibility
-LABEL io.s2i.scripts-url=image:///usr/local/sti
+LABEL io.s2i.scripts-url=image:///usr/bin
 
 # Deprecated. Use above LABEL instead, because this will be removed in future versions.
-ENV STI_SCRIPTS_URL=image:///usr/local/sti
+ENV STI_SCRIPTS_URL=image:///usr/bin
 
 # Labels consumed by Red Hat build service
 LABEL BZComponent="openshift-sti-base-docker" \
@@ -24,7 +24,7 @@ LABEL BZComponent="openshift-sti-base-docker" \
 # properly as Docker image metadata, which causes the $PATH variable do not
 # expand properly.
 ENV HOME=/opt/app-root/src \
-    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sti:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
@@ -76,7 +76,7 @@ RUN yum install -y --setopt=tsflags=nodocs \
 
 # Create directory where the image STI scripts will be located
 # Install the base-usage script with base image usage informations
-ADD bin/base-usage /usr/local/sti/base-usage
+ADD bin/base-usage /usr/bin/base-usage
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -10,7 +10,7 @@ LABEL io.s2i.scripts-url=image:///usr/libexec/s2i
 # Deprecated. Use above LABEL instead, because this will be removed in future versions.
 ENV STI_SCRIPTS_URL=image:///usr/libexec/s2i
 
-# Path to be used in other layers to place s2i scritps into
+# Path to be used in other layers to place s2i scripts into
 ENV STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 # Labels consumed by Red Hat build service


### PR DESCRIPTION
Since we're trying to come up with guidelines and best practices for creating docker images, I'm also thinking about things like locations of files within the container. This is a proposal to change location of sti scripts.

The reasons for this change are:
* what FHS says about '/usr/local':
The '/usr/local' hierarchy is for use by the system administrator when installing software locally. It needs to be safe from being overwritten when the system software is updated. It may be used for programs and data that are shareable amongst a group of hosts, but not found in '/usr'. (http://www.pathname.com/fhs/pub/fhs-2.3.html#USRLOCALLOCALHIERARCHY)
* we may include the sti scripts in the RPMs once (in that case it would probably be links managed by alternatives, since various implementations of /usr/bin/run will be different across images)
* we need to have those commands available for and run by users, so I don't see any special reason to handle them differently than other commands