### PR TITLE
Add entrypoint so the commands as CMD on non-standard path are found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,13 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 # Install the base-usage script with base image usage informations
 ADD bin/base-usage /usr/local/sti/base-usage
 
+# Use entrypoint so path is correctly adjusted already at the time the command
+# is searching, so something like docker run IMG python runs binary from SCL
+ADD bin/container-entrypoint /usr/bin/container-entrypoint
+
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path
 WORKDIR ${HOME}
 
+ENTRYPOINT ["container-entrypoint"]
 CMD ["base-usage"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -78,8 +78,13 @@ RUN yum install -y --setopt=tsflags=nodocs \
 # Install the base-usage script with base image usage informations
 ADD bin/base-usage /usr/local/sti/base-usage
 
+# Use entrypoint so path is correctly adjusted already at the time the command
+# is searching, so something like docker run IMG python runs binary from SCL
+ADD bin/container-entrypoint /usr/bin/container-entrypoint
+
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path
 WORKDIR ${HOME}
 
+ENTRYPOINT ["container-entrypoint"]
 CMD ["base-usage"]

--- a/bin/container-entrypoint
+++ b/bin/container-entrypoint
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+cmd="$1"; shift
+exec $cmd "$@"
+


### PR DESCRIPTION
With current sti-base image the following runs python 2.7, while one would expect python 3.3:

  #> docker pull openshift3/python-34-rhel7
  #> docker run --rm -ti openshift3/python-34-rhel7 python --version
  Python 2.7.5

Adding entrypoint will ensure correct PATH is set also at the time the CMD is being found.