### PR TITLE
default to group 0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,9 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   zlib-devel && \
   yum clean all -y && \
   mkdir -p ${HOME} && \
-  groupadd -r default -f -g 1001 && \
-  useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
+  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
       -c "Default Application User" default && \
-  chown -R 1001:1001 /opt/app-root
+  chown -R 1001:0 /opt/app-root
 
 # Create directory where the image STI scripts will be located
 # Install the base-usage script with base image usage informations

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -69,10 +69,9 @@ RUN yum install -y --setopt=tsflags=nodocs \
   zlib-devel && \
   yum clean all -y && \
   mkdir -p ${HOME} && \
-  groupadd -r default -f -g 1001 && \
-  useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
+  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
       -c "Default Application User" default && \
-  chown -R 1001:1001 /opt/app-root
+  chown -R 1001:0 /opt/app-root
 
 # Create directory where the image STI scripts will be located
 # Install the base-usage script with base image usage informations


### PR DESCRIPTION
this will ensure source code is writable by the uid running the container on openshift (the container uid is always a member of gid 0).  This will allow users to docker exec  (or oc exec) into the running container and manipulate source code to do dynamic debugging/testing.

previously the source code was only writable by uid 1001/gid 1001 which never corresponded to the uid/gid running the container once it was deployed in openshift.
