### PR TITLE
Enable rhel-7-server-optional-rpms for bsdtar

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -39,7 +39,8 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
 # Also setup the 'openshift' user that is used for the build execution and for the
 # application runtime execution.
 # TODO: Use better UID and GID values
-RUN yum install -y --setopt=tsflags=nodocs \
+RUN yum-config-manager --enable rhel-7-server-optional-rpms && \
+  yum install -y --setopt=tsflags=nodocs \
   autoconf \
   automake \
   bsdtar \


### PR DESCRIPTION
I don't know if this is necessary for centos or not