### PR TITLE
Set MAX_MEMORY_LIMIT_IN_BYTES to number returned by cgroups where there is no limit

### DIFF
--- a/bin/cgroup-limits.py
+++ b/bin/cgroup-limits.py
@@ -36,5 +36,6 @@ def get_number_of_cores():
 get_memory_limit()
 get_number_of_cores()
 
+print("MAX_MEMORY_LIMIT_IN_BYTES=9223372036854775807")
 for item in env_vars.items():
     print("=".join(item))


### PR DESCRIPTION
You can listen to this while reviewing this PR: https://www.youtube.com/watch?v=qM5W7Xn7FiA