### PR TITLE
Remove .py suffix from cgroup-limits script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ COPY bin/container-entrypoint /usr/bin/container-entrypoint
 COPY bin/fix-permissions /usr/bin/fix-permissions
 
 # Add utility for parsing cgroup limits
-COPY bin/cgroup-limits.py /usr/bin/cgroup-limits.py
+COPY bin/cgroup-limits /usr/bin/cgroup-limits
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -90,7 +90,7 @@ COPY bin/container-entrypoint /usr/bin/container-entrypoint
 COPY bin/fix-permissions /usr/bin/fix-permissions
 
 # Add utility for parsing cgroup limits
-COPY bin/cgroup-limits.py /usr/bin/cgroup-limits.py
+COPY bin/cgroup-limits /usr/bin/cgroup-limits
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path

--- a/bin/cgroup-limits
+++ b/bin/cgroup-limits
@@ -9,8 +9,7 @@ successfully read. Output of this script can be directly fed into
 bash's export command. Recommended usage from a bash script:
 
     set -o errexit
-    export_vars=$(cgroup-limits.py)
-    export $export_vars
+    export_vars=$(cgroup-limits) ; export $export_vars
 
 Variables currently supported:
     MAX_MEMORY_LIMIT_IN_BYTES


### PR DESCRIPTION
@rhcarvalho @bparees